### PR TITLE
fix: remove caching from setSystemConfig

### DIFF
--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -1581,15 +1581,8 @@ export class Connection<
 	 */
 	setSystemConfig(
 		obj: ioBroker.SettableObjectWorker<ioBroker.OtherObject>,
-	): Promise<ioBroker.SettableObjectWorker<ioBroker.OtherObject>> {
-		return this.request({
-			// TODO: check if this should time out
-			commandTimeout: false,
-			executor: async (resolve) => {
-				await this.setObject("system.config", obj);
-				resolve(obj);
-			},
-		});
+	): Promise<void> {
+		return this.setObject("system.config", obj);
 	}
 
 	/**


### PR DESCRIPTION
After `getSystemConfig`, the cache key was set and would prevent the call from ever happening.

fixes: #8 