### PR TITLE
fix: reload on websocket error instead of alert()-ing

### DIFF
--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -325,6 +325,7 @@ export class Connection<
 			if (_err.includes("User not authorized")) {
 				this.authenticate();
 			} else if (_err.includes("websocket error")) {
+				console.error(`Socket Error => reload: ${err}`);
 				window.location.reload();
 			} else {
 				console.error(`Socket Error: ${err}`);

--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -239,7 +239,9 @@ export class Connection<
 			protocol = parsed.protocol.replace(":", "");
 		}
 
-		const url = port || port === '80' || port === '443' ? `${protocol}://${host}:${port}` : `${protocol}://${host}`;
+		const url = port
+			? `${protocol}://${host}:${port}`
+			: `${protocol}://${host}`;
 
 		this._socket = window.io.connect(url, {
 			query: protocol == "ws" || protocol == "wss" ? "ws=true" : "",
@@ -322,8 +324,10 @@ export class Connection<
 
 			if (_err.includes("User not authorized")) {
 				this.authenticate();
+			} else if (_err.includes("websocket error")) {
+				window.location.reload();
 			} else {
-				window.alert(`Socket Error: ${err}`);
+				console.error(`Socket Error: ${err}`);
 			}
 		});
 


### PR DESCRIPTION
I noticed that when I visit my application on iOS, minimize the browser and later come back, I'm greeted with a websocket error `alert`. This is now detected and the page gets reloaded instead.